### PR TITLE
Update rotate_logs.sh

### DIFF
--- a/packages/core/etc/simplevm/utils/rotate_logs.sh
+++ b/packages/core/etc/simplevm/utils/rotate_logs.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
 
-# Define the log file path
-LOG_FILE="/var/log/metadata.log"
+# Define the log file path, maximum size (default: 10 MB), and cut size (default: 5 MB)
+METADATA_LOG_FILE_PATH="/var/log/metadata.log"
+MAX_SIZE=${MAX_SIZE:-$((10 * 1024 * 1024))} # Max size in bytes
+CUT_SIZE=${CUT_SIZE:-$((5 * 1024 * 1024))}  # Target size in bytes
 
-
-# Check if the file exists
-if [[ -e "$LOG_FILE" ]]; then
+# Check if the file exists and is a regular file
+if [[ -f "$METADATA_LOG_FILE_PATH" ]]; then
     # Get the file size in bytes
-    FILE_SIZE=$(stat -c%s "$LOG_FILE")
+    FILE_SIZE=$(stat -c%s "$METADATA_LOG_FILE_PATH")
 
-    # Convert 10 MB to bytes for comparison
-    MAX_SIZE=$((10 * 1024 * 1024))
-    # Check if the file size exceeds 10 MB
+    # Check if the file size exceeds the maximum size
     if (( FILE_SIZE > MAX_SIZE )); then
-        # Remove the top 100 lines from the file
-        # and overwrite the file with the result
-        tail -n +101 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
-    fi
+        # Use a temporary file and safely handle rotation
+        TEMP_FILE="${METADATA_LOG_FILE_PATH}.tmp"
 
+        # Calculate the number of bytes to retain (equal to CUT_SIZE)
+        BYTES_TO_RETAIN=$CUT_SIZE
+
+        # Retain only the last BYTES_TO_RETAIN bytes and overwrite the original file
+        tail -c "$BYTES_TO_RETAIN" "$METADATA_LOG_FILE_PATH" > "$TEMP_FILE" &&
+            mv "$TEMP_FILE" "$METADATA_LOG_FILE_PATH"
+
+        # Log a message to indicate that the file was truncated
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - File $METADATA_LOG_FILE_PATH exceeded maximum size ($MAX_SIZE bytes). Truncated to $CUT_SIZE bytes." >> /var/log/metadata_cleanup.log
+    fi
+else
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - File $METADATA_LOG_FILE_PATH does not exist or is not a regular file." >> /var/log/metadata_cleanup.log
 fi


### PR DESCRIPTION
Updated rotate log Script.

The old script still had the problem - that if the response from the metadata server is larger than 100 lines (e.g. with many public keys, or if we add more information) - the log will still become larger because only 100 lines are removed.

Now the script defines a maximum size of the log and a size to which the log is shortened when the maximum size is reached