### PR TITLE
fix(SSH-Service): Adjusted referenced service

### DIFF
--- a/packages/users/DEBIAN/control
+++ b/packages/users/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: simplevm-metadata-service-public-key-synchronization
 Source: simplevm-metadata-service
-Version: 0.1.5
+Version: 0.1.6
 Section: base
 Priority: optional
 Architecture: all

--- a/packages/users/DEBIAN/postinst
+++ b/packages/users/DEBIAN/postinst
@@ -36,7 +36,7 @@ rm "${SSHD_CONFIG_FILE}.bak"
 
 systemctl daemon-reload
 
-service sshd restart
+service ssh restart
 
 # Enable the service and timer
 systemctl enable public-keys-sync.service


### PR DESCRIPTION
@dweinholz 
sshd-service was just a link to ssh-service in ubuntu versions <=22.
Got changed in 24.04, so an easy adjustment was to rename the service called for restart
