### PR TITLE
Feat/tmr

### DIFF
--- a/packages/core/DEBIAN/control
+++ b/packages/core/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: simplevm-metadata-service-core
 Source: simplevm-metadata-service
-Version: 0.1.10
+Version: 0.1.11
 Section: base
 Priority: optional
 Architecture: all

--- a/packages/core/DEBIAN/control
+++ b/packages/core/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: simplevm-metadata-service-core
 Source: simplevm-metadata-service
-Version: 0.1.11
+Version: 0.1.12
 Section: base
 Priority: optional
 Architecture: all

--- a/packages/core/etc/simplevm/utils/get_metadata.sh
+++ b/packages/core/etc/simplevm/utils/get_metadata.sh
@@ -101,7 +101,7 @@ fi
   key_not_found_flag=$(echo "$metadata_response" | jq -r '.detail')
 
   if [ "$key_not_found_flag" == "Key not found" ]; then
-      echo "Key not found in the response. Extending interval..."
+      echo "Key not found in the response."
       reset_interval
       exit 1
   elif [ "$key_not_found_flag" == "Too Many Requests" ]; then

--- a/packages/core/etc/simplevm/utils/get_metadata.sh
+++ b/packages/core/etc/simplevm/utils/get_metadata.sh
@@ -92,7 +92,6 @@ full_response=$(curl -s -o - -w "%{http_code}" -X GET "${REAL_METADATA_ENDPOINT}
 
 response_status="${full_response: -3}"
 metadata_response="${full_response%???}"
-metadata_response=$(curl -s -X GET "${REAL_METADATA_ENDPOINT}/metadata/${LOCAL_IP}" -H "${AUTH_HEADER}")
 
 if [ $? -ne 0 ]; then
   log_message "Error: Failed to fetch metadata"

--- a/packages/core/etc/simplevm/utils/get_metadata.sh
+++ b/packages/core/etc/simplevm/utils/get_metadata.sh
@@ -121,30 +121,41 @@ if [ "$response_status" -eq 200 ]; then
     exit 1
   fi
 
-elif [ "$response_status" -eq 400 ] || [ "$response_status" -eq 403 ]; then
-    echo "Error: Too many requests sent to the server. Extending interval..."
-    extend_interval
-    exit 1
+elif [ "$response_status" -eq 400 ]; then
+  echo "Error: Bad request sent to the server. Extending interval..."
+  extend_interval
+  exit 1
+
+elif [ "$response_status" -eq 403 ]; then
+  echo "Error: Forbidden request. Not allowed to access this resource. Extending interval..."
+  extend_interval
+  exit 1
+    
 
 elif [ "$response_status" -eq 404 ]; then
-    echo "Key not found in the response."
-    reset_interval
-    exit 1
+  echo "Error: Key not found in the response. Resetting interval..."
+  reset_interval
+  exit 1
+
+elif [ "$response_status" -eq 429 ]; then
+  echo "Error: Too many requests received from this client. Extending interval..."
+  extend_interval
+  exit 1
 
 elif [ "$response_status" -eq 503 ] || [ "$response_status" -eq 504 ]; then
-    echo "Service unavailable or gateway timeout. Extending interval..."
-    extend_interval
-    exit 1
+  echo "Error: Service unavailable or gateway timeout. Extending interval..."
+  extend_interval
+  exit 1
 
 elif [ "$response_status" -eq 500 ]; then
-    echo "Internal server error. Resetting interval..."
-    reset_interval
-    exit 1
+  echo "Internal server error. Resetting interval..."
+  reset_interval
+  exit 1
 
 else
-    echo "Unexpected error or server condition. HTTP Status: $response_status"
-    reset_interval
-    exit 1
+  echo "Unexpected error or server condition. HTTP Status: $response_status. Resetting interval..."
+  reset_interval
+  exit 1
 fi
 
 

--- a/packages/core/etc/simplevm/utils/get_metadata.sh
+++ b/packages/core/etc/simplevm/utils/get_metadata.sh
@@ -3,20 +3,51 @@
 LOG_FILE="/var/log/metadata.log"
 METADATA_OUTPUT_FILE="/etc/simplevm/metadata.json"
 
-/etc/simplevm/utils/rotate_logs.sh
-/etc/simplevm/utils/update_compatibilities.sh
-
-
-current_interval=$(grep '^OnUnitActiveSec=' $TIMER_PATH | cut -d= -f2 | sed 's/min//')
-default_interval="5min"
-max_interval="30min"
-TIMER_PATH="/etc/systemd/system/simplevm-metadata-synchronizer.timer"
-
-source /etc/simplevm/metadata_config.env
-
 log_message() {
   echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$LOG_FILE"
 }
+
+TIMER_PATH="/etc/systemd/system/simplevm-metadata-synchronizer.timer"
+
+DEFAULT_INTERVAL="5min"
+MAX_INTERVAL="30min"
+
+current_interval=$(grep '^OnUnitActiveSec=' $TIMER_PATH | cut -d= -f2 | sed 's/min//')
+log_message "This is my interval: ${current_interval}"
+
+
+set_new_interval() {
+    # Update the timer file
+    sudo sed -i "s/^OnUnitActiveSec=.*/OnUnitActiveSec=$1/" $TIMER_PATH
+    # Reload systemd to apply changes
+    sudo systemctl daemon-reload
+    # Restart the timer with the new interval
+    sudo systemctl restart simplevm-metadata-synchronizer.timer
+}
+
+extend_interval() {
+    # Calculate the new interval
+    new_interval=$((current_interval + 5))
+    # Ensure we do not exceed the max interval
+    if (( new_interval > MAX_INTERVAL )); then
+        new_interval=$MAX_INTERVAL
+    fi
+    echo "Extending timer interval to ${new_interval} minutes"
+    set_new_interval "${new_interval}min"
+}
+
+reset_interval() {
+    echo "Resetting timer interval to default: $DEFAULT_INTERVAL"
+    set_new_interval "$DEFAULT_INTERVAL"
+}
+
+/etc/simplevm/utils/rotate_logs.sh
+#/etc/simplevm/utils/update_compatibilities.sh
+
+
+
+source /etc/simplevm/metadata_config.env
+
 
 # Construct the URL with hostname query param
 INFO_ENDPOINT_URL="${METADATA_INFO_ENDPOINT}?hostname=$(hostname)"
@@ -26,6 +57,8 @@ AUTH_HEADER="auth_token: ${METADATA_ACCESS_TOKEN}"
 
 # Get real metadata endpoint from config if available
 REAL_METADATA_ENDPOINT=$(grep '^REAL_METADATA_ENDPOINT=' "/etc/simplevm/metadata_config.env" | cut -d '=' -f 2-)
+
+
 
 if [ -z "${REAL_METADATA_ENDPOINT}" ]; then
   # Fetch the JSON response from the info endpoint to get real metadata endpoint
@@ -52,7 +85,9 @@ if [ -z "${REAL_METADATA_ENDPOINT}" ]; then
 fi
 
 # Fetch the actual metadata from the extracted endpoint
-LOCAL_IP=$(hostname -I | awk '{print $1}')
+LOCAL_IP="192.168.2.37" # adjust for development purposes
+log_message ${LOCAL_IP}
+#LOCAL_IP=$(hostname -I | awk '{print $1}')
 metadata_response=$(curl -s -X GET "${REAL_METADATA_ENDPOINT}/metadata/${LOCAL_IP}" -H "${AUTH_HEADER}")
 
 if [ $? -ne 0 ]; then
@@ -73,28 +108,3 @@ else
   extend_interval
   log_message "Error: Failed to save metadata to ${METADATA_OUTPUT_FILE}"
 fi
-
-set_new_interval() {
-    # Update the timer file
-    sudo sed -i "s/^OnUnitActiveSec=.*/OnUnitActiveSec=$1/" $TIMER_PATH
-    # Reload systemd to apply changes
-    sudo systemctl daemon-reload
-    # Restart the timer with the new interval
-    sudo systemctl restart simplevm-metadata-synchronizer.timer
-}
-
-extend_interval() {
-    # Calculate the new interval
-    new_interval=$((current_interval + 5))
-    # Ensure we do not exceed the max interval
-    if (( new_interval > MAX_INTERVAL )); then
-        new_interval=$MAX_INTERVAL
-    fi
-    echo "Extending timer interval to ${new_interval} minutes"
-    set_new_interval "${new_interval}min"
-}
-
-reset_interval() {
-    echo "Resetting timer interval to default: $DEFAULT_INTERVAL"
-    set_new_interval "$DEFAULT_INTERVAL"
-}

--- a/packages/core/etc/simplevm/utils/get_metadata.sh
+++ b/packages/core/etc/simplevm/utils/get_metadata.sh
@@ -6,6 +6,12 @@ METADATA_OUTPUT_FILE="/etc/simplevm/metadata.json"
 /etc/simplevm/utils/rotate_logs.sh
 /etc/simplevm/utils/update_compatibilities.sh
 
+
+current_interval=$(grep '^OnUnitActiveSec=' $TIMER_PATH | cut -d= -f2 | sed 's/min//')
+default_interval="5min"
+max_interval="30min"
+TIMER_PATH="/etc/systemd/system/simplevm-metadata-synchronizer.timer"
+
 source /etc/simplevm/metadata_config.env
 
 log_message() {
@@ -27,12 +33,14 @@ if [ -z "${REAL_METADATA_ENDPOINT}" ]; then
 
   if [ $? -ne 0 ]; then
     log_message "Error: Failed to fetch metadata endpoint"
-    exit 1
+    extend_interval
+    exit 1  
   fi
 
   # Validate the JSON response
   if ! jq -e '.metadata_endpoint' <<< "${info_response}" &> /dev/null; then
     log_message "Error: Invalid JSON response from metadata endpoint"
+    extend_interval
     exit 1
   fi
 
@@ -49,6 +57,7 @@ metadata_response=$(curl -s -X GET "${REAL_METADATA_ENDPOINT}/metadata/${LOCAL_I
 
 if [ $? -ne 0 ]; then
   log_message "Error: Failed to fetch metadata"
+  extend_interval
   exit 1
 fi
 
@@ -59,6 +68,33 @@ echo "${metadata_response}"| jq > "${TMP_FILE}"
 # Rename the temporary file to the original filename
 if mv -f "${TMP_FILE}" "${METADATA_OUTPUT_FILE}"; then
   log_message "Metadata saved to ${METADATA_OUTPUT_FILE}"
+  reset_interval
 else
+  extend_interval
   log_message "Error: Failed to save metadata to ${METADATA_OUTPUT_FILE}"
 fi
+
+set_new_interval() {
+    # Update the timer file
+    sudo sed -i "s/^OnUnitActiveSec=.*/OnUnitActiveSec=$1/" $TIMER_PATH
+    # Reload systemd to apply changes
+    sudo systemctl daemon-reload
+    # Restart the timer with the new interval
+    sudo systemctl restart simplevm-metadata-synchronizer.timer
+}
+
+extend_interval() {
+    # Calculate the new interval
+    new_interval=$((current_interval + 5))
+    # Ensure we do not exceed the max interval
+    if (( new_interval > MAX_INTERVAL )); then
+        new_interval=$MAX_INTERVAL
+    fi
+    echo "Extending timer interval to ${new_interval} minutes"
+    set_new_interval "${new_interval}min"
+}
+
+reset_interval() {
+    echo "Resetting timer interval to default: $DEFAULT_INTERVAL"
+    set_new_interval "$DEFAULT_INTERVAL"
+}

--- a/packages/dev-controls/control-core
+++ b/packages/dev-controls/control-core
@@ -1,6 +1,6 @@
 Package: simplevm-metadata-service-core-dev
 Source: simplevm-metadata-service-dev
-Version: 0.1.9
+Version: 0.1.12
 Section: base
 Priority: optional
 Architecture: all

--- a/packages/dev-controls/control-meta
+++ b/packages/dev-controls/control-meta
@@ -1,10 +1,10 @@
 Package: simplevm-metadata-service-dev
 Source: simplevm-metadata-service-dev
-Version: 0.2.0
+Version: 0.2.2
 Section: metapackages
 Priority: optional
 Architecture: all
-Depends: simplevm-metadata-service-public-key-synchronization-dev (>= 0.1.8), simplevm-metadata-service-core-dev (>= 0.1.9), simplevm-metadata-service-auto-update-dev (>= 0.0.1)
+Depends: simplevm-metadata-service-public-key-synchronization-dev (>= 0.1.8), simplevm-metadata-service-core-dev (>= 0.1.12), simplevm-metadata-service-auto-update-dev (>= 0.0.1)
 Maintainer: SimpleVM Development Team<cloud@denbi.de>
 Uploaders: Nils Hoffmann <n.hoffmann@fz-juelich.de>, Qiqi Mok <q.mok@fz-juelich.de>, Peter Belmann <p.belmann@fz-juelich.de>, David Weinholz<d.weinholz@fz-juelich.de>, Viktor Rudko<v.rudko@fz-juelich.de>
 Description: Core service that enables the retrieval of metadata from the Metadata-Server in the SimpleVM environment.

--- a/packages/meta/DEBIAN/control
+++ b/packages/meta/DEBIAN/control
@@ -1,10 +1,10 @@
 Package: simplevm-metadata-service
 Source: simplevm-metadata-service
-Version: 0.2.1
+Version: 0.2.2
 Section: metapackages
 Priority: optional
 Architecture: all
-Depends: simplevm-metadata-service-public-key-synchronization (>= 0.1.8), simplevm-metadata-service-core (>= 0.1.11), simplevm-metadata-service-auto-update (>= 0.0.1)
+Depends: simplevm-metadata-service-public-key-synchronization (>= 0.1.8), simplevm-metadata-service-core (>= 0.1.12), simplevm-metadata-service-auto-update (>= 0.0.1)
 Maintainer: SimpleVM Development Team<cloud@denbi.de>
 Uploaders: Nils Hoffmann <n.hoffmann@fz-juelich.de>, Qiqi Mok <q.mok@fz-juelich.de>, Peter Belmann <p.belmann@fz-juelich.de>, David Weinholz<d.weinholz@fz-juelich.de>, Viktor Rudko<v.rudko@fz-juelich.de>
 Description: Core service that enables the retrieval of metadata from the Metadata-Server in the SimpleVM environment.

--- a/packages/meta/DEBIAN/control
+++ b/packages/meta/DEBIAN/control
@@ -1,10 +1,10 @@
 Package: simplevm-metadata-service
 Source: simplevm-metadata-service
-Version: 0.2.0
+Version: 0.2.1
 Section: metapackages
 Priority: optional
 Architecture: all
-Depends: simplevm-metadata-service-public-key-synchronization (>= 0.1.8), simplevm-metadata-service-core (>= 0.1.9), simplevm-metadata-service-auto-update (>= 0.0.1)
+Depends: simplevm-metadata-service-public-key-synchronization (>= 0.1.8), simplevm-metadata-service-core (>= 0.1.11), simplevm-metadata-service-auto-update (>= 0.0.1)
 Maintainer: SimpleVM Development Team<cloud@denbi.de>
 Uploaders: Nils Hoffmann <n.hoffmann@fz-juelich.de>, Qiqi Mok <q.mok@fz-juelich.de>, Peter Belmann <p.belmann@fz-juelich.de>, David Weinholz<d.weinholz@fz-juelich.de>, Viktor Rudko<v.rudko@fz-juelich.de>
 Description: Core service that enables the retrieval of metadata from the Metadata-Server in the SimpleVM environment.


### PR DESCRIPTION
@dweinholz 
Adjusting the timer (add 5 minutes on each faulty request until 30min max is reached, than stay there - adjust to default of 5 minutes of request was successful again)

metadata-server running localy with test-mode can be used for testing quite well.